### PR TITLE
Add openssh-client and ca-certificates to image

### DIFF
--- a/testbox/Dockerfile
+++ b/testbox/Dockerfile
@@ -49,12 +49,14 @@ CMD ["/entrypoint.sh"]
 # hadolint ignore=DL3008,DL3009
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
+        ca-certificates \
         curl \
         git \
         man \
         ncat \
         nvi \
         shellcheck \
+        ssh-client \
         sudo \
         tmux
 


### PR DESCRIPTION
Add openssh-client and ca-certificates to image, which I believe adds about 10MB to image size.

I thought SSH was already in. When I tested some things with GitHub Enterprise Server today I needed to install
openssh-client and ca-certificates to make it all work.

Alternatively to adding openssh-client to the base image, you could install it [in `solv-ssh-client`](https://github.com/solvaholic/docker/blob/main/testbox/vm_files/usr/local/bin/solv-ssh-client)